### PR TITLE
Scale energy estimate by resource allocation in Teads model

### DIFF
--- a/src/__tests__/unit/lib/teads-curve/index.test.ts
+++ b/src/__tests__/unit/lib/teads-curve/index.test.ts
@@ -26,6 +26,32 @@ describe('teads:configure test', () => {
       },
     ]);
   });
+  test('scale with vcpu usage', async () => {
+    const outputModel = new TeadsCurveModel();
+    await outputModel.configure({
+      'thermal-design-power': 200,
+    });
+    await expect(
+      outputModel.execute([
+        {
+          duration: 3600,
+          'cpu-util': 50.0,
+          timestamp: '2021-01-01T00:00:00Z',
+          'vcpus-allocated': 1,
+          'vcpus-total': 64,
+        },
+      ])
+    ).resolves.toStrictEqual([
+      {
+        'energy-cpu': 0.00234375,
+        duration: 3600,
+        'cpu-util': 50.0,
+        timestamp: '2021-01-01T00:00:00Z',
+        'vcpus-allocated': 1,
+        'vcpus-total': 64,
+      },
+    ]);
+  });
   test('teads:initialize with params:spline', async () => {
     const outputModel = new TeadsCurveModel();
     await outputModel.configure({

--- a/src/lib/teads-curve/README.md
+++ b/src/lib/teads-curve/README.md
@@ -25,6 +25,10 @@ IF recognizes the Teads CPU model as `teads-curve`.
 - `energy-cpu`: The energy used by the CPU, in kWh
 
 
+> **Note** If `vcpus-allocated` and `vcpus-total` are available, these data will be used to scale the CPU energy usage. If they are not present, we assume the entire processor is being used. For example, if only 1 out of 64 available vCPUS are allocated, we scale the processor TDP by 1/64.
+
+
+
 ## Implementation
 
 ### Linear Interpolation

--- a/src/lib/teads-curve/index.ts
+++ b/src/lib/teads-curve/index.ts
@@ -81,7 +81,6 @@ export class TeadsCurveModel implements ModelPluginInterface {
           throw new Error('invalid type for vcpus-total');
         }
 
-        console.log('updating energy');
         energy = energy * (allocated / total);
       }
       input['energy-cpu'] = energy;

--- a/src/lib/teads-curve/index.ts
+++ b/src/lib/teads-curve/index.ts
@@ -65,7 +65,6 @@ export class TeadsCurveModel implements ModelPluginInterface {
       let total: number;
       let allocated: number;
       if ('vcpus-allocated' in input && 'vcpus-total' in input) {
-        console.log('IN HERE');
         if (typeof input['vcpus-allocated'] === 'string') {
           allocated = parseFloat(input['vcpus-allocated']);
         } else if (typeof input['vcpus-allocated'] === 'number') {


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request

The energy estimated by the Teads model is now scaled by the `vcpu-allocated` and `vcpu-total` values if they are provided. For example, if only 1 out of 64 vCPUs are allocated, the energy used by the processor is scaled by 1/64. If no data is available, we assume the entire processor is being used and do not scale.

<!-- Make sure tests and lint pass on CI. -->

Closes https://github.com/Green-Software-Foundation/if/issues/271
